### PR TITLE
Align device listing status filter with Kapua connection status

### DIFF
--- a/internal/kapua/handlers/devices.go
+++ b/internal/kapua/handlers/devices.go
@@ -15,11 +15,11 @@ import (
 
 // ListDevicesParams defines parameters for listing devices
 type ListDevicesParams struct {
-	ClientID  string `json:"clientId,omitempty" jsonschema:"Filter devices by client ID"`
-	Status    string `json:"status,omitempty" jsonschema:"Filter devices by status (ENABLED/DISABLED)"`
-	MatchTerm string `json:"matchTerm,omitempty" jsonschema:"Search term to match against device fields"`
-	Limit     int    `json:"limit,omitempty" jsonschema:"Maximum number of devices to return (default: 50)"`
-	Offset    int    `json:"offset,omitempty" jsonschema:"Number of devices to skip (default: 0)"`
+	ClientID         string                  `json:"clientId,omitempty" jsonschema:"Filter devices by client ID"`
+	ConnectionStatus models.ConnectionStatus `json:"status,omitempty" jsonschema:"Filter devices by connection status (CONNECTED/DISCONNECTED/MISSING/NULL)"`
+	MatchTerm        string                  `json:"matchTerm,omitempty" jsonschema:"Search term to match against device fields"`
+	Limit            int                     `json:"limit,omitempty" jsonschema:"Maximum number of devices to return (default: 50)"`
+	Offset           int                     `json:"offset,omitempty" jsonschema:"Number of devices to skip (default: 0)"`
 }
 
 // CreateDeviceParams defines parameters for creating a device
@@ -51,8 +51,8 @@ func (h *KapuaHandler) HandleListDevices(ctx context.Context, req *mcp.CallToolR
 	if params.ClientID != "" {
 		queryParams["clientId"] = params.ClientID
 	}
-	if params.Status != "" {
-		queryParams["status"] = params.Status
+	if params.ConnectionStatus != "" {
+		queryParams["status"] = string(params.ConnectionStatus)
 	}
 	if params.MatchTerm != "" {
 		queryParams["matchTerm"] = params.MatchTerm

--- a/internal/kapua/handlers/devices_test.go
+++ b/internal/kapua/handlers/devices_test.go
@@ -43,8 +43,8 @@ func TestHandleListDevicesSuccess(t *testing.T) {
 		if r.URL.Query().Get("clientId") != "acme" {
 			t.Fatalf("expected clientId acme, got %s", r.URL.Query().Get("clientId"))
 		}
-		if r.URL.Query().Get("status") != "ENABLED" {
-			t.Fatalf("expected status ENABLED, got %s", r.URL.Query().Get("status"))
+		if r.URL.Query().Get("status") != string(models.ConnectionStatusConnected) {
+			t.Fatalf("expected status %s, got %s", models.ConnectionStatusConnected, r.URL.Query().Get("status"))
 		}
 		if r.URL.Query().Get("matchTerm") != "sensor" {
 			t.Fatalf("expected matchTerm sensor, got %s", r.URL.Query().Get("matchTerm"))
@@ -65,7 +65,7 @@ func TestHandleListDevicesSuccess(t *testing.T) {
 		_, _ = w.Write(data)
 	})
 
-	params := &ListDevicesParams{ClientID: "acme", Status: "ENABLED", MatchTerm: "sensor", Limit: 25, Offset: 5}
+	params := &ListDevicesParams{ClientID: "acme", ConnectionStatus: models.ConnectionStatusConnected, MatchTerm: "sensor", Limit: 25, Offset: 5}
 	result, _, err := handler.HandleListDevices(context.Background(), nil, params)
 	if err != nil {
 		t.Fatalf("HandleListDevices returned error: %v", err)

--- a/internal/kapua/models/devices.go
+++ b/internal/kapua/models/devices.go
@@ -10,6 +10,16 @@ const (
 	DeviceStatusDisabled DeviceStatus = "DISABLED"
 )
 
+// ConnectionStatus represents the connection status filter for devices
+type ConnectionStatus string
+
+const (
+	ConnectionStatusConnected    ConnectionStatus = "CONNECTED"
+	ConnectionStatusDisconnected ConnectionStatus = "DISCONNECTED"
+	ConnectionStatusMissing      ConnectionStatus = "MISSING"
+	ConnectionStatusNull         ConnectionStatus = "NULL"
+)
+
 // Device represents a Kapua device
 type Device struct {
 	KapuaEntity


### PR DESCRIPTION
## Summary
- align the device listing tool parameters with the Kapua connection status filter values
- add explicit connection status constants to the Kapua models package for reuse
- update the list devices handler test to validate the connection status query parameter

## Testing
- go test ./...