### PR TITLE
Add health check endpoint and corresponding test

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,5 +36,7 @@ COPY --from=builder /out/kapua-mcp-server /app/kapua-mcp-server
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 
 EXPOSE 8000
+# Health check endpoint: GET /health returns {"status":"ok"}
+# Configure probes in your orchestrator (e.g. Kubernetes httpGet on /health).
 ENTRYPOINT ["/app/kapua-mcp-server"]
-CMD ["-http", "--host", "0.0.0.0", "--port", "8000"]
+CMD ["-http", "-host", "0.0.0.0", "-port", "8000"]

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -68,7 +68,17 @@ func (s *Server) Handler(httpCfg *HTTPConfig) http.Handler {
 		logger = utils.NewDefaultLogger("MCPServer")
 	}
 
-	return newOriginMiddleware(httpCfg, logger, streamHandler)
+	mcpHandler := newOriginMiddleware(httpCfg, logger, streamHandler)
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"status":"ok"}`))
+	})
+	mux.Handle("/", mcpHandler)
+
+	return mux
 }
 
 func (s *Server) ListenAndServe(addr string, handler http.Handler) error {

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -72,6 +72,10 @@ func (s *Server) Handler(httpCfg *HTTPConfig) http.Handler {
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write([]byte(`{"status":"ok"}`))

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -150,19 +150,40 @@ func TestHealthEndpoint(t *testing.T) {
 
 	handler := srv.Handler(&HTTPConfig{})
 
-	req := httptest.NewRequest(http.MethodGet, "/health", nil)
-	rec := httptest.NewRecorder()
-	handler.ServeHTTP(rec, req)
+	t.Run("GET returns 200 with status ok", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/health", nil)
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, req)
 
-	if rec.Code != http.StatusOK {
-		t.Fatalf("expected 200, got %d", rec.Code)
-	}
-	if ct := rec.Header().Get("Content-Type"); ct != "application/json" {
-		t.Fatalf("expected application/json, got %s", ct)
-	}
-	body := rec.Body.String()
-	if body != `{"status":"ok"}` {
-		t.Fatalf("unexpected body: %s", body)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d", rec.Code)
+		}
+		if ct := rec.Header().Get("Content-Type"); ct != "application/json" {
+			t.Fatalf("expected application/json, got %s", ct)
+		}
+		body := rec.Body.String()
+		if body != `{"status":"ok"}` {
+			t.Fatalf("unexpected body: %s", body)
+		}
+	})
+
+	for _, method := range []string{
+		http.MethodPost,
+		http.MethodPut,
+		http.MethodPatch,
+		http.MethodDelete,
+		http.MethodHead,
+		http.MethodOptions,
+	} {
+		t.Run(method+" returns 405 Method Not Allowed", func(t *testing.T) {
+			req := httptest.NewRequest(method, "/health", nil)
+			rec := httptest.NewRecorder()
+			handler.ServeHTTP(rec, req)
+
+			if rec.Code != http.StatusMethodNotAllowed {
+				t.Fatalf("expected 405, got %d", rec.Code)
+			}
+		})
 	}
 }
 

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -139,6 +139,33 @@ func TestRegisterKapuaHelpers(t *testing.T) {
 	}
 }
 
+func TestHealthEndpoint(t *testing.T) {
+	srv := &Server{
+		logger: utils.NewDefaultLogger("test"),
+		kapuaCfg: &config.Config{
+			Kapua: config.KapuaConfig{APIEndpoint: "https://example"},
+		},
+		mcpServer: mcpsdk.NewServer(&mcpsdk.Implementation{Name: "test", Version: "dev"}, nil),
+	}
+
+	handler := srv.Handler(&HTTPConfig{})
+
+	req := httptest.NewRequest(http.MethodGet, "/health", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+	if ct := rec.Header().Get("Content-Type"); ct != "application/json" {
+		t.Fatalf("expected application/json, got %s", ct)
+	}
+	body := rec.Body.String()
+	if body != `{"status":"ok"}` {
+		t.Fatalf("unexpected body: %s", body)
+	}
+}
+
 func TestRunTransportNilTransport(t *testing.T) {
 	srv := &Server{
 		logger: utils.NewDefaultLogger("test"),


### PR DESCRIPTION
This pull request adds a new health check endpoint to the MCP server, making it easier to monitor the application's status in production environments. The `/health` endpoint returns a simple JSON response indicating the server is running. The change is documented in the Dockerfile, and a corresponding test ensures the endpoint works as expected.

**Health check endpoint:**

* Added a new `/health` HTTP endpoint to the server, which returns a `{"status":"ok"}` JSON response with a 200 status code. This is implemented in the `Handler` method by adding a new route to the HTTP mux.
* Added a test (`TestHealthEndpoint`) to verify that the `/health` endpoint returns the correct status code, content type, and response body.

**Documentation and configuration:**

* Updated the `Dockerfile` to document the `/health` endpoint and suggest configuring health probes in orchestrators (e.g., Kubernetes).
* Fixed a minor typo in the `CMD` arguments in the `Dockerfile` (`--host`/`--port` → `-host`/`-port`).